### PR TITLE
Mock network access in tests

### DIFF
--- a/META.json
+++ b/META.json
@@ -61,7 +61,8 @@
             "Test::Deep" : "0.112",
             "Test::Exception" : "0.32",
             "Test::More" : "1.001003",
-            "Test::Pod" : "0"
+            "Test::Pod" : "0",
+            "Test::LWP::UserAgent" : "0.026"
          }
       }
    },

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ on 'test', sub {
   requires 'Test::Exception', '0.32';
   requires 'Test::More', '1.001003';
   requires 'Test::Pod', 0;
+  requires 'Test::LWP::UserAgent', '0.026';
 };
 
 requires 'Cache::LRU', '0.04';

--- a/lib/RDF/LDF.pm
+++ b/lib/RDF/LDF.pm
@@ -22,18 +22,15 @@ use JSON;
 use URI::Template;
 
 our $VERSION = '0.04';
+{
+	my $ua	= RDF::Trine->default_useragent;
+	$ua->agent("RDF:::LDF/$RDF::LDF::VERSION " . $ua->_agent);
+}
+
 
 has url => (
     is => 'ro' ,
     required => 1
-);
-
-has ua => (
-    is      => 'ro',
-    lazy    => 1,
-    builder => sub {
-        LWP::UserAgent->new( agent => "RDF:::LDF/$RDF::LDF::VERSION" );
-    }
 );
 
 has sn => (

--- a/lib/RDF/Trine/Store/LDF.pm
+++ b/lib/RDF/Trine/Store/LDF.pm
@@ -15,9 +15,7 @@ use RDF::Trine::Error qw(:try);
 sub new {
     my ($class,%opts) = @_;
     my $ref = \%opts;
-    my %args = (url => $ref->{url});
-    $args{ua} = $ref->{ua} if ($ref->{ua});
-    $ref->{ldf} =  RDF::LDF->new(%args);
+    $ref->{ldf} =  RDF::LDF->new( url => $ref->{url});
 
     return undef unless $ref->{ldf}->is_fragment_server;
     
@@ -30,7 +28,7 @@ sub _new_with_string {
 }
 sub _new_with_config {
     my ($class,$cfg) = @_;
-    $class->new(url => $cfg->{url}, ua => $cfg->{ua});
+    $class->new(url => $cfg->{url});
 }
 
 sub get_statements {

--- a/lib/RDF/Trine/Store/LDF.pm
+++ b/lib/RDF/Trine/Store/LDF.pm
@@ -14,7 +14,9 @@ use RDF::LDF;
 sub new {
     my ($class,%opts) = @_;
     my $ref = \%opts;
-    $ref->{ldf} =  RDF::LDF->new( url => $ref->{url});
+    my %args = (url => $ref->{url});
+    $args{ua} = $ref->{ua} if ($ref->{ua});
+    $ref->{ldf} =  RDF::LDF->new(%args);
     bless $ref , $class;
 }
 
@@ -24,7 +26,7 @@ sub _new_with_string {
 }
 sub _new_with_config {
     my ($class,$cfg) = @_;
-    $class->new(url => $cfg->{url});
+    $class->new(url => $cfg->{url}, ua => $cfg->{ua});
 }
 
 sub get_statements {

--- a/t/LDF-pattern.t
+++ b/t/LDF-pattern.t
@@ -15,8 +15,9 @@ my $client = RDF::LDF->new(url => 'http://example.org/2014/en?test=1');
 ok $client , 'got a client to http://example.org/2014/en?test=1';
 ok $client->is_fragment_server , 'this server is a ldf server';
 
-if (0) {
-	my $triple	= statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('o'));
+{
+	diag("single triple pattern");
+	my $triple	= statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('place'));
 	my $iter	= $client->get_pattern($triple);
 	isa_ok $iter, 'RDF::Trine::Iterator::Bindings', 'iterator for get_pattern';
 	my $r		= $iter->next;
@@ -27,6 +28,7 @@ if (0) {
 }
 
 {
+	diag("two triple pattern BGP");
 	my $bgp		= RDF::Query::Algebra::BasicGraphPattern->new(
 		statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('place')),
 		statement(variable('s'), iri('http://xmlns.com/foaf/0.1/name'), variable('name')),

--- a/t/LDF-pattern.t
+++ b/t/LDF-pattern.t
@@ -1,0 +1,175 @@
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Data::Dumper;
+use RDF::Trine qw(statement iri variable);
+use RDF::LDF;
+use Test::LWP::UserAgent;
+
+RDF::Trine->default_useragent(user_agent());
+
+my $client = RDF::LDF->new(url => 'http://example.org/2014/en?test=1');
+
+ok $client , 'got a client to http://example.org/2014/en?test=1';
+ok $client->is_fragment_server , 'this server is a ldf server';
+
+if (0) {
+	my $triple	= statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('o'));
+	my $iter	= $client->get_pattern($triple);
+	isa_ok $iter, 'RDF::Trine::Iterator::Bindings', 'iterator for get_pattern';
+	my $r		= $iter->next;
+	isa_ok $r, 'RDF::Trine::VariableBindings', 'result object';
+	my $s		= $r->{'s'};
+	isa_ok $s, 'RDF::Trine::Node::Resource', 'expected subject IRI';
+	is $s->value, 'http://dbpedia.org/resource/Agusti_Pol', 'expected subject IRI value';
+}
+
+{
+	my $bgp		= RDF::Query::Algebra::BasicGraphPattern->new(
+		statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('place')),
+		statement(variable('s'), iri('http://xmlns.com/foaf/0.1/name'), variable('name')),
+	);
+	my $iter	= $client->get_pattern($bgp);
+	isa_ok $iter, 'RDF::Trine::Iterator::Bindings', 'iterator for get_pattern';
+	
+	my $count	= 0;
+	my %seen;
+	while (my $r = $iter->next) {
+		isa_ok $r, 'RDF::Trine::VariableBindings', 'result object';
+		my $s	= $r->{'s'};
+		$seen{ $s->value }{count}++;
+		push(@{ $seen{ $s->value }{name} }, $r->{'name'}->value);
+		push(@{ $seen{ $s->value }{place} }, $r->{'place'}->value);
+		$count++;
+	}
+	is $count, 3, 'result count';
+	is_deeply(\%seen, {
+		'http://dbpedia.org/resource/Agustiar_Batubara' => {
+			'count' => 2,
+			'name' => ['Agustiar Batubara', 'Agustiar Batubara'],
+			'place' => [ 'http://dbpedia.org/resource/Indonesia', 'http://dbpedia.org/resource/Surabaya'],
+		},
+		'http://dbpedia.org/resource/Agusti_Pol' => {
+			'count' => 1,
+			'name' => [ 'Agusti Pol'],
+			'place' => [ 'http://dbpedia.org/resource/Andorra'],
+		}
+	}, 'expected counts');
+}
+
+done_testing;
+
+sub add_fragment_response {
+	my $ua		= shift;
+	my $url		= shift;
+	my $content	= shift;
+	my $total	= shift // 1;
+	my $next	= shift;
+	my $NS		= <<'END';
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix dbpedia: <http://dbpedia.org/resource/> .
+@prefix dbpedia-owl: <http://dbpedia.org/ontology/> .
+@prefix dbpprop: <http://dbpedia.org/property/> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+END
+	my $META	= <<'END';
+<http://example.org/#dataset> hydra:member <http://example.org/2014/en?test=1#dataset> .
+<http://example.org/2014/en?test=1#dataset>
+    void:subset <http://example.org/2014/en?test=1> ;
+    void:uriLookupEndpoint "http://example.org/2014/en?test=1{&subject,predicate,object}" ;
+    a void:Dataset, hydra:Collection ;
+    hydra:search [
+        hydra:mapping [
+            hydra:property rdf:object ;
+            hydra:variable "object"
+        ], [
+            hydra:property rdf:predicate ;
+            hydra:variable "predicate"
+        ], [
+            hydra:property rdf:subject ;
+            hydra:variable "subject"
+        ] ;
+        hydra:template "http://example.org/2014/en?test=1{&subject,predicate,object}"
+    ] .
+END
+
+	my $FRAGMENT	= <<"END";
+<$url>
+    dc:description "Triple Pattern Fragment of the 'DBpedia 2014' dataset containing triples matching the pattern { ?s ?p ?o }." ;
+    dc:source <http://example.org/2014/en?test=1#dataset> ;
+    dc:title "Linked Data Fragment of DBpedia 2014" ;
+    void:subset <http://example.org/2014/en?test=1> ;
+    a hydra:Collection, hydra:PagedCollection ;
+#    hydra:firstPage <$url> ;
+    hydra:itemsPerPage 5 ;
+    void:triples $total ;
+    hydra:totalItems $total .
+END
+	if (defined($next)) {
+		$FRAGMENT .= <<"END";
+<$url> hydra:nextPage <$next> .
+END
+	}
+	$ua->map_response(
+		qr{^\Q$url\E$},
+		HTTP::Response->new('200', 'OK', ['Content-Type' => 'text/plain'], $NS . $META . $FRAGMENT . $content));
+}
+
+sub user_agent {
+	my $ua = Test::LWP::UserAgent->new( agent => "RDF:::LDF/$RDF::LDF::VERSION" );
+	
+	# ?s dbpedia-owl:birthPlace ?name
+	my $birthPlaces = <<'END';
+dbpedia:Agusti_Pol dbpedia-owl:birthPlace dbpedia:Andorra .
+dbpedia:Agustiar_Batubara dbpedia-owl:birthPlace dbpedia:Indonesia, dbpedia:Surabaya .
+dbpedia:Agustin_Aguayo dbpedia-owl:birthPlace dbpedia:Guadalajara .
+END
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1', $birthPlaces, 4);
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=%3Fs&predicate=http%3A%2F%2Fdbpedia.org%2Fontology%2FbirthPlace&object=%3Fplace', $birthPlaces, 3);
+
+	# ?s foaf:name ?name (page 1)
+	my $names	= <<'END';
+<http://dbpedia.org/resource/4th_arrondissement_of_Marseille> foaf:name "4th arrondissement of Marseille"@en .
+<http://dbpedia.org/resource/4th_arrondissement_of_Paris> foaf:name "4th arrondissement of Paris"@en .
+<http://dbpedia.org/resource/4th_arrondissement_of_Porto-Novo> foaf:name "4th arrondissement of Porto-Novo"@en .
+<http://dbpedia.org/resource/4th_arrondissement_of_the_Littoral_Department> foaf:name "4th arrondissement"@en .
+<http://dbpedia.org/resource/4th_municipality_of_Naples> foaf:name "Fourth Municipality of Naples"@en, "Municipalità 4"@en, "Quarta  Municipalità"@en .
+END
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=%3Fs&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname', $names, 7, 'http://example.org/2014/en?test=1&subject=%3Fs&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname&page=2');
+
+	# ?s foaf:name ?name (page 2)
+	my $names2	= <<'END';
+dbpedia:Agusti_Pol foaf:name "Agusti Pol" .
+dbpedia:Agustiar_Batubara foaf:name "Agustiar Batubara" .
+END
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=%3Fs&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname&page=2', $names, 7);
+
+	# dbpedia:Agusti_Pol foaf:name ?name
+	my $pol_name	= <<'END';
+dbpedia:Agusti_Pol foaf:name "Agusti Pol" .
+END
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=http%3A%2F%2Fdbpedia.org%2Fresource%2FAgusti_Pol&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname', $pol_name, 1);
+
+	# dbpedia:Agustiar_Batubara foaf:name ?name
+	my $batubara_name	= <<'END';
+dbpedia:Agustiar_Batubara foaf:name "Agustiar Batubara" .
+END
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=http%3A%2F%2Fdbpedia.org%2Fresource%2FAgustiar_Batubara&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname', $batubara_name, 1);
+
+	# dbpedia:Agustin_Aguayo foaf:name ?name (No results)
+	add_fragment_response($ua, 'http://example.org/2014/en?test=1&subject=http%3A%2F%2Fdbpedia.org%2Fresource%2FAgustin_Aguayo&predicate=http%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2Fname&object=%3Fname', '', 0);
+	
+	return $ua;
+}
+

--- a/t/LDF-pattern.t
+++ b/t/LDF-pattern.t
@@ -16,7 +16,7 @@ ok $client , 'got a client to http://example.org/2014/en?test=1';
 ok $client->is_fragment_server , 'this server is a ldf server';
 
 {
-	diag("single triple pattern");
+	note("single triple pattern");
 	my $triple	= statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('place'));
 	my $iter	= $client->get_pattern($triple);
 	isa_ok $iter, 'RDF::Trine::Iterator::Bindings', 'iterator for get_pattern';
@@ -28,7 +28,7 @@ ok $client->is_fragment_server , 'this server is a ldf server';
 }
 
 {
-	diag("two triple pattern BGP");
+	note("two triple pattern BGP");
 	my $bgp		= RDF::Query::Algebra::BasicGraphPattern->new(
 		statement(variable('s'), iri('http://dbpedia.org/ontology/birthPlace'), variable('place')),
 		statement(variable('s'), iri('http://xmlns.com/foaf/0.1/name'), variable('name')),

--- a/t/RDF-LDF.t
+++ b/t/RDF-LDF.t
@@ -5,8 +5,9 @@ use Test::More;
 use Test::Exception;
 use Data::Dumper;
 use RDF::LDF;
+use Test::LWP::UserAgent;
 
-my $client = RDF::LDF->new(url => 'http://fragments.dbpedia.org/2014/en');
+my $client = RDF::LDF->new(url => 'http://fragments.dbpedia.org/2014/en', ua => user_agent());
 
 ok $client , 'got a client to http://fragments.dbpedia.org/2014/en';
 
@@ -29,3 +30,60 @@ ok $info , 'got ldf metadata';
 ok $info->{void_triples}  , 'got lotsa triples';
 
 done_testing;
+
+sub user_agent {
+	my $DBPEDIA_FRAGMENT = <<'END';
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<http://commons.wikimedia.org/wiki/Special:FilePath/!!!善福寺.JPG>
+    dc11:rights <http://en.wikipedia.org/wiki/File:!!!善福寺.JPG> ;
+    foaf:thumbnail <http://commons.wikimedia.org/wiki/Special:FilePath/!!!善福寺.JPG?width=300> .
+
+<http://fragments.dbpedia.org/#dataset>
+    hydra:member <http://fragments.dbpedia.org/2014/en#dataset> .
+
+<http://fragments.dbpedia.org/2014/en>
+    dc:description "Triple Pattern Fragment of the 'DBpedia 2014' dataset containing triples matching the pattern { ?s ?p ?o }."@en ;
+    dc:source <http://fragments.dbpedia.org/2014/en#dataset> ;
+    dc:title "Linked Data Fragment of DBpedia 2014"@en ;
+    void:subset <http://fragments.dbpedia.org/2014/en> ;
+    void:triples 367999560 ;
+    a hydra:Collection, hydra:PagedCollection ;
+    hydra:firstPage <http://fragments.dbpedia.org/2014/en?page=1> ;
+    hydra:itemsPerPage 100 ;
+    hydra:nextPage <http://fragments.dbpedia.org/2014/en?page=2> ;
+    hydra:totalItems 367999560 .
+
+<http://fragments.dbpedia.org/2014/en#dataset>
+    void:subset <http://fragments.dbpedia.org/2014/en> ;
+    void:uriLookupEndpoint "http://fragments.dbpedia.org/2014/en{?subject,predicate,object}" ;
+    a void:Dataset, hydra:Collection ;
+    hydra:search [
+        hydra:mapping [
+            hydra:property rdf:object ;
+            hydra:variable "object"
+        ], [
+            hydra:property rdf:predicate ;
+            hydra:variable "predicate"
+        ], [
+            hydra:property rdf:subject ;
+            hydra:variable "subject"
+        ] ;
+        hydra:template "http://fragments.dbpedia.org/2014/en{?subject,predicate,object}"
+    ] .
+
+END
+
+	my $ua = Test::LWP::UserAgent->new( agent => "RDF:::LDF/$RDF::LDF::VERSION" );
+	$ua->map_response(
+		qr{http://fragments.dbpedia.org/2014/en},
+		HTTP::Response->new('200', 'OK', ['Content-Type' => 'text/plain'], $DBPEDIA_FRAGMENT));
+	return $ua;
+}
+

--- a/t/RDF-LDF.t
+++ b/t/RDF-LDF.t
@@ -7,7 +7,9 @@ use Data::Dumper;
 use RDF::LDF;
 use Test::LWP::UserAgent;
 
-my $client = RDF::LDF->new(url => 'http://fragments.dbpedia.org/2014/en', ua => user_agent());
+RDF::Trine->default_useragent(user_agent());
+
+my $client = RDF::LDF->new(url => 'http://fragments.dbpedia.org/2014/en');
 
 ok $client , 'got a client to http://fragments.dbpedia.org/2014/en';
 


### PR DESCRIPTION
I ran into some weird test failure when initially trying out this code, and realized that it was due to my local network blocking some of the requests. I've changed RDF-LDF.t and added a new LDF-pattern.t that test RDF::LDF using Test::LWP::UserAgent to mock the network accesses, controlling all the data that is used while testing.

I didn't change RDF-Trine-Store-LDF.t mostly because it involves LOTS of requests that would be a lot of work to mock. Making these tests always execute runs the risk of causing failures (and preventing installation) just because the machine doesn't (during the testing) have network access to, e.g., DBPedia. I would suggest making this test dependent on some environment variable that can be set by testing environments that can guarantee network access. For example, see: https://github.com/kasei/perlrdf/blob/master/RDF-Trine/t/parser.t#L19
