### PR TITLE
Use LWP::UserAgent::CHICaching

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,7 @@ on 'test', sub {
   requires 'Encode', 0;
 };
 
-requires 'Cache::LRU', 0;
+requires 'LWP::UserAgent::CHICaching', 0;
 requires 'Clone', 0;
 requires 'Data::Compare', 0;
 requires 'Getopt::Long', 0;

--- a/t/LDF-pattern-federated.t
+++ b/t/LDF-pattern-federated.t
@@ -9,13 +9,13 @@ use Test::LWP::UserAgent;
 use Encode;
 use utf8;
 
-RDF::Trine->default_useragent(user_agent());
-
 my $client = RDF::LDF->new(url => [qw(
             http://example.org/A
             http://example.org/C
             http://example.org/B
-            )]);
+            )],
+									ua => user_agent()
+								  );
 
 ok $client , 'got a federated client to http://example.org/A ,  http://example.org/B and  http://example.org/C ... ';
 ok $client->is_fragment_server , 'this server is a ldf server';

--- a/t/LDF-pattern.t
+++ b/t/LDF-pattern.t
@@ -9,9 +9,8 @@ use Test::LWP::UserAgent;
 use Encode;
 use utf8;
 
-RDF::Trine->default_useragent(user_agent());
-
-my $client = RDF::LDF->new(url => 'http://example.org/2014/en?test=1');
+my $client = RDF::LDF->new(url => 'http://example.org/2014/en?test=1', 
+									ua => Test::LWP::UserAgent->new);
 
 ok $client , 'got a client to http://example.org/2014/en?test=1';
 ok $client->is_fragment_server , 'this server is a ldf server';

--- a/t/LDF-pattern.t
+++ b/t/LDF-pattern.t
@@ -10,7 +10,7 @@ use Encode;
 use utf8;
 
 my $client = RDF::LDF->new(url => 'http://example.org/2014/en?test=1', 
-									ua => Test::LWP::UserAgent->new);
+									ua => user_agent());
 
 ok $client , 'got a client to http://example.org/2014/en?test=1';
 ok $client->is_fragment_server , 'this server is a ldf server';


### PR DESCRIPTION
Hi!

The following patch has three effects:
1) It moves the caching logic to the User Agent.
2) It makes the User Agent more customizable since it is passed as an argument
3) It supports parts of the HTTP standard

And BTW, LWP::UserAgent::CHICaching is a module I have developed for this purpose :-) It didn't seem that the use of Cache::LRU did anything to check the Cache-Control headers and such, and that is kinda ok, it is the UA's responsiblity to do that. But then, an UA that does it should be used. Also, this UA can use a cache based on the CHI module, so is can use e.g. Redis, memcached, etc as cache.

So, I think this patch is important. Happy to discuss, but I will be offline much of next week.

Kjetil
