### PR TITLE
Just remove the caching code

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,7 +9,6 @@ on 'test', sub {
   requires 'Encode', 0;
 };
 
-requires 'Cache::LRU', 0;
 requires 'Clone', 0;
 requires 'Data::Compare', 0;
 requires 'Getopt::Long', 0;
@@ -25,6 +24,8 @@ requires 'RDF::Trine', 0;
 requires 'Throwable', 0;
 requires 'URI::Escape', 0;
 requires 'URI::Template', 0;
+
+recommends 'LWP::UserAgent::CHICaching', 0;
 
 recommends 'Log::Any', '1.00';
 recommends 'Moo', '1.004006';

--- a/lib/RDF/LDF.pm
+++ b/lib/RDF/LDF.pm
@@ -616,6 +616,13 @@ RDF::LDF - Linked Data Fragments client
     use RDF::Trine::Store::LDF;
     use RDF::Trine::Store;
 
+    # To use a HTTP cache:
+    use LWP::UserAgent::CHICaching;
+    my $cache = CHI->new( driver => 'Memory', global => 1 );
+    my $ua = LWP::UserAgent::CHICaching->new(cache => $cache);
+    RDF::Trine->default_useragent($ua);
+
+
     my $store = RDF::Trine::Store->new_with_config({
             storetype => 'LDF',
             url => $url

--- a/lib/RDF/LDF.pm
+++ b/lib/RDF/LDF.pm
@@ -698,6 +698,8 @@ Gregory Todd Williams, C<< greg@evilfunhouse.com >>
 
 Jacob Voss, C<< voss@gbv.de >>
 
+Kjetil Kjernsmo, C<< kjetilk@cpan.org >>
+
 =head1 COPYRIGHT AND LICENSE
 
 This software is copyright (c) 2015 by Patrick Hochstenbach.


### PR DESCRIPTION
Hi again!

I wonder if this is a better idea... It makes the caching entirely the responsibility of the UA, and uses the existing RDF::Trine mechanism for setting the UA. This passes all my tests.

My only problem is that I don't really have tests to verify that caching actually works... Any suggestions?

What could be helpful is that [Test::LWP::UserAgent docs](https://metacpan.org/pod/Test::LWP::UserAgent) say 

> One common mechanism to swap out the useragent implementation is via a lazily-built Moose 
> attribute; if no override is provided at construction time, default to `LWP::UserAgent->new(%options)`.

but I have to admit I don't really understand what they mean...
