### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ perl:
     - "5.18"
     - "5.16"
 
+arch:
+    - AMD64
+    - ppc64le
+
 install:
     - cpanm --quiet --notest --skip-satisfied Dist::Milla
     - cpanm --installdeps .


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.